### PR TITLE
Update TemplateMessageBuilder.php addHeader

### DIFF
--- a/src/Services/TemplateMessageBuilder.php
+++ b/src/Services/TemplateMessageBuilder.php
@@ -98,28 +98,41 @@ class TemplateMessageBuilder
      * @return self
      * @throws InvalidArgumentException Si el componente no es válido.
      */
-    public function addHeader(string $type, $content): self
     {
         $this->ensureTemplateStructureLoaded();
         $this->validateComponent('HEADER', $type);
-        
+
         $formattedParams = [];
-        if (!is_array($content)) {
-            $content = [$content];
+
+        if( $type=='IMAGE' ){
+            //foreach ($content as $item) {
+                $formattedParams[] = [
+                    'type' => 'image',
+                    'image' => [
+                        'link' => $content
+                    ]
+                ];
+            //}
+
+            $this->components['HEADER']['type'] = 'header';
         }
-        
-        foreach ($content as $item) {
-            $formattedParams[] = [
-                'type' => 'text',
-                'text' => $item
-            ];
+        else{
+            if (!is_array($content)) {
+                $content = [$content];
+            }
+
+            foreach ($content as $item) {
+                $formattedParams[] = [
+                    'type' => 'text',
+                    'link' => $item
+                ];
+            }
+
+            $this->components['HEADER']['type'] = $type;
         }
-        
-        $this->components['HEADER'] = [
-            'type' => $type,
-            'parameters' => $formattedParams
-        ];
-        
+
+        $this->components['HEADER']['parameters'] = $formattedParams;
+
         return $this;
     }
 


### PR DESCRIPTION
Cuando se usa una plantilla que tiene un header de tipo imagen, el método addHEader no está armando correctamente los parámetros para dicho tipo "IMAGE" envío la corrección para que funcione correctamente cuando se agrega un header de tipo imagen.