### PR TITLE
Update TemplateMessageBuilder.php sendMessage

### DIFF
--- a/src/Services/TemplateMessageBuilder.php
+++ b/src/Services/TemplateMessageBuilder.php
@@ -446,13 +446,13 @@ class TemplateMessageBuilder
             'phone_number' => $this->phoneNumber,
         ]);
 
-        $contact = Contact::where('wa_id', $this->phoneNumber)->first();
+        //$contact = Contact::where('wa_id', $this->phoneNumber)->first(); //Es innecesario, ya se creó/actualizó dentro del método "to", no tiene caso volver a llamar a la base de datos
 
         $message = Message::create([
             'whatsapp_phone_id' => $this->phone->phone_number_id,
             'contact_id' => $this->contact->contact_id,
             'message_from' => $this->phone->display_phone_number,
-            'message_to' => $contact->wa_id,
+            'message_to' => $this->contact->wa_id, //Se corrige esta variable, usar $this->contact en lugar de $contact
             'message_type' => 'template',
             'message_content' => NULL,
             'message_method' => 'OUTPUT',


### PR DESCRIPTION
En el método “to” agregaste una corrección para crear o actualizar el contacto y lo asignaste a la variable $this->contact en la línea 69, eso está bien, pero cuando se envía un mensaje de una plantilla, el paso final del proceso es el método “sendMessage”, ahí tienes la línea $contact = Contact::where('wa_id', $this->phoneNumber)->first(); pero ya no es necesaria ya que la variable $this->contact ya tiene esa información, es innecesario llamar de nuevo a la base de datos, por lo que esta línea la comentéy mas abajo cuando creas el registro del mensaje se usará la variable $this->contact en lugar de la variable “$contact”