### PR TITLE
Update WhatsappWebhookController.php splitPhoneNumber

### DIFF
--- a/src/Http/Controllers/WhatsappWebhookController.php
+++ b/src/Http/Controllers/WhatsappWebhookController.php
@@ -23,6 +23,7 @@ use ScriptDevelop\WhatsappManager\Models\WhatsappPhoneNumber;
 use ScriptDevelop\WhatsappManager\Helpers\CountryCodes;
 use ScriptDevelop\WhatsappManager\Models\MediaFile;
 use ScriptDevelop\WhatsappManager\Enums\StepType;
+use Illuminate\Support\Str; // <-- Agregamos esto
 
 class WhatsappWebhookController extends Controller
 {
@@ -539,6 +540,11 @@ class WhatsappWebhookController extends Controller
         foreach ($codes as $code) {
             if (str_starts_with($fullPhone, $code)) {
                 $phoneNumber = substr($fullPhone, strlen($code));
+                //Si el país es México, según ChatGPT este es el único caso en el mundo que tiene un 1 después del código de area y luego vienen 10 dígitos del celular así 521 1234567890
+                //Por lo tanto comprobar si es número de méxico y el $phoneNumber son exactamente 10 números, entonces agregar el 1 inicial
+                if( $code==52 && Str::length($phoneNumber)==10 ){
+                    $phoneNumber = '1'.$phoneNumber;
+                }
                 return [$code, $phoneNumber];
             }
         }


### PR DESCRIPTION
Se agrega código especial para el caso de México, es el único país del mundo según ChatGPT que después del código de area 52 agrega 1 y luego los 10 dígitos del celular, ese 1 se usa cuando es llamada internacional y significa que es un celular, desde el interior de la República Mexicana es 1 se omite, pero para estandarizarlo se pondrá siempre ese 1