### PR TITLE
Update TemplateMessageBuilder.php método "to"

### DIFF
--- a/src/Services/TemplateMessageBuilder.php
+++ b/src/Services/TemplateMessageBuilder.php
@@ -53,7 +53,7 @@ class TemplateMessageBuilder
      */
     public function to(string $countryCode, string $phoneNumber,): self
     {
-        $codes = CountryCodes::list();
+        $codes = CountryCodes::codes();
 
         if (!in_array($countryCode, $codes)) {
             throw new InvalidArgumentException("El código de país '$countryCode' no es válido.");


### PR DESCRIPTION
Se verifica que la variable $countryCode esté dentro del arreglo que está en el archivo CountryCodes, pero se estaba llamando al método list "CountryCodes::codes()" pero ese archivo ahora lo adecuado es usar el método codes "CountryCodes::codes()", esto lo corrige