### PR TITLE
Ahora el webhook actualiza el campo "is_active"

### DIFF
--- a/src/Config/whatsapp.php
+++ b/src/Config/whatsapp.php
@@ -64,6 +64,8 @@ return [
 
         'template_flow' => \ScriptDevelop\WhatsappManager\Models\WhatsappTemplateFlow::class,
 
+        'blocked_user' => \ScriptDevelop\WhatsappManager\Models\BlockedUser::class,
+
         // Modelo de usuario (puede ser personalizado)
         'user_model' => env('AUTH_MODEL', App\Models\User::class),
 

--- a/src/Http/Controllers/WhatsappWebhookController.php
+++ b/src/Http/Controllers/WhatsappWebhookController.php
@@ -972,7 +972,8 @@ class WhatsappWebhookController extends Controller
             if ($lastVersion) {
                 $lastVersion->update([
                     'status' => $newStatus,
-                    'rejection_reason' => $reason
+                    'rejection_reason' => $reason,
+                    'is_active' => ($templateData['event'] === 'APPROVED'),
                 ]);
             } else {
                 // Caso excepcional: no hay versiones pero debemos crear una

--- a/src/Models/BlockedUser.php
+++ b/src/Models/BlockedUser.php
@@ -27,11 +27,11 @@ class BlockedUser extends Model
 
     public function phoneNumber()
     {
-        return $this->belongsTo(WhatsappPhoneNumber::class, 'phone_number_id');
+        return $this->belongsTo(config('whatsapp.models.phone_number'), 'phone_number_id');
     }
 
     public function contact()
     {
-        return $this->belongsTo(Contact::class, 'contact_id');
+        return $this->belongsTo(config('whatsapp.models.contact'), 'contact_id');
     }
 }

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -56,7 +56,7 @@ class Contact extends Model
     {
         return $this->hasMany(config('whatsapp.models.message'), 'contact_id');
     }
-::
+
     public function latestMessage($phoneNumberId)
     {
         return $this->messages()

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -54,9 +54,9 @@ class Contact extends Model
 
     public function messages()
     {
-        return $this->hasMany(Message::class, 'contact_id');
+        return $this->hasMany(config('whatsapp.models.message'), 'contact_id');
     }
-
+::
     public function latestMessage($phoneNumberId)
     {
         return $this->messages()
@@ -81,7 +81,7 @@ class Contact extends Model
 
     public function blockedStatuses()
     {
-        return $this->hasMany(BlockedUser::class, 'contact_id');
+        return $this->hasMany(config('whatsapp.models.blocked_user'), 'contact_id');
     }
 
     public function isBlockedOn(string $phoneNumberId): bool
@@ -97,7 +97,7 @@ class Contact extends Model
         if ($this->isBlockedOn($phoneNumberId)) {
             return false;
         }
-        
+
         $service = app(BlockService::class);
         $response = $service->blockUsers($phoneNumberId, [$this->wa_id]);
         return $response['success'] ?? false;
@@ -108,7 +108,7 @@ class Contact extends Model
         if (!$this->isBlockedOn($phoneNumberId)) {
             return false;
         }
-        
+
         $service = app(BlockService::class);
         $response = $service->unblockUsers($phoneNumberId, [$this->wa_id]);
         return $response['success'] ?? false;

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -29,6 +29,6 @@ class Conversation extends Model
 
     public function messages()
     {
-        return $this->hasMany(Message::class, 'conversation_id');
+        return $this->hasMany(config('whatsapp.models.message'), 'conversation_id');
     }
 }

--- a/src/Models/MediaFile.php
+++ b/src/Models/MediaFile.php
@@ -32,6 +32,6 @@ class MediaFile extends Model
 
     public function message()
     {
-        return $this->belongsTo(Message::class, 'message_id');
+        return $this->belongsTo(config('whatsapp.models.message'), 'message_id');
     }
 }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -195,40 +195,40 @@ class Message extends Model
 
     public function contact()
     {
-        return $this->belongsTo(Contact::class, 'contact_id');
+        return $this->belongsTo(config('whatsapp.models.contact'), 'contact_id');
     }
 
     public function conversation()
     {
-        return $this->belongsTo(Conversation::class, 'conversation_id');
+        return $this->belongsTo(config('whatsapp.models.conversation'), 'conversation_id');
     }
 
     public function phoneNumber()
     {
-        return $this->belongsTo(WhatsappPhoneNumber::class, 'whatsapp_phone_id');
+        return $this->belongsTo(config('whatsapp.models.phone_number'), 'whatsapp_phone_id');
     }
 
     public function mediaFiles()
     {
-        return $this->hasMany(MediaFile::class, 'message_id');
+        return $this->hasMany(config('whatsapp.models.media_file'), 'message_id');
     }
 
     public function parentMessage()
     {
         // Relación uno a uno: este mensaje pertenece a un mensaje de contexto
-        return $this->belongsTo(Message::class, 'message_context_id', 'message_id');
+        return $this->belongsTo(config('whatsapp.models.message'), 'message_context_id', 'message_id');
     }
 
     public function replies()
     {
         // Relación uno a muchos: este mensaje tiene múltiples réplicas
-        return $this->hasMany(Message::class, 'message_id', 'message_context_id');
+        return $this->hasMany(config('whatsapp.models.message'), 'message_id', 'message_context_id');
     }
 
     // Relación con la versión de plantilla
     public function templateVersion()
     {
-        return $this->belongsTo(TemplateVersion::class, 'template_version_id');
+        return $this->belongsTo(config('whatsapp.models.template_version'), 'template_version_id');
     }
 
     public function getDisplayContentAttribute()

--- a/src/Models/Template.php
+++ b/src/Models/Template.php
@@ -37,7 +37,7 @@ class Template extends Model
 
     public function businessAccount()
     {
-        return $this->belongsTo(WhatsappBusinessAccount::class, 'whatsapp_business_id');
+        return $this->belongsTo(config('whatsapp.models.business_account'), 'whatsapp_business_id');
     }
 
     /**
@@ -45,23 +45,23 @@ class Template extends Model
      */
     public function category()
     {
-        return $this->belongsTo(TemplateCategory::class, 'category_id', 'category_id'); // Usar 'category_id'
+        return $this->belongsTo(config('whatsapp.models.template_category'), 'category_id', 'category_id'); // Usar 'category_id'
     }
 
     public function languageData()
     {
-        return $this->belongsTo(TemplateLanguage::class, 'language', 'id');
+        return $this->belongsTo(config('whatsapp.models.template_language'), 'language', 'id');
     }
 
     public function components()
     {
-        return $this->hasMany(TemplateComponent::class, 'template_id', 'template_id');
+        return $this->hasMany(config('whatsapp.models.template_component'), 'template_id', 'template_id');
     }
 
     public function flows()
     {
         return $this->belongsToMany(
-            WhatsappFlow::class, 'whatsapp_template_flows', 'template_id', 'flow_id'
+            config('whatsapp.models.flow'), 'whatsapp_template_flows', 'template_id', 'flow_id'
         );
     }
 
@@ -96,13 +96,13 @@ class Template extends Model
     // Relación con versiones
     public function versions()
     {
-        return $this->hasMany(TemplateVersion::class, 'template_id');
+        return $this->hasMany(config('whatsapp.models.template_version'), 'template_id');
     }
 
     // Relación con la última versión aprobada
     public function activeVersion()
     {
-        return $this->hasOne(TemplateVersion::class, 'template_id')
+        return $this->hasOne(config('whatsapp.models.template_version'), 'template_id')
             ->where('is_active', true);
     }
 

--- a/src/Models/TemplateCategory.php
+++ b/src/Models/TemplateCategory.php
@@ -27,6 +27,6 @@ class TemplateCategory extends Model
      */
     public function templates()
     {
-        return $this->hasMany(Template::class, 'category_id', 'category_id');
+        return $this->hasMany(config('whatsapp.models.template'), 'category_id', 'category_id');
     }
 }

--- a/src/Models/TemplateComponent.php
+++ b/src/Models/TemplateComponent.php
@@ -34,6 +34,6 @@ class TemplateComponent extends Model
      */
     public function template()
     {
-        return $this->belongsTo(Template::class, 'template_id', 'template_id');
+        return $this->belongsTo(config('whatsapp.models.template'), 'template_id', 'template_id');
     }
 }

--- a/src/Models/TemplateLanguage.php
+++ b/src/Models/TemplateLanguage.php
@@ -25,6 +25,6 @@ class TemplateLanguage extends Model
 
     public function templates()
     {
-        return $this->hasMany(Template::class, 'language', 'id');
+        return $this->hasMany(config('whatsapp.models.template'), 'language', 'id');
     }
 }

--- a/src/Models/TemplateVersion.php
+++ b/src/Models/TemplateVersion.php
@@ -34,6 +34,6 @@ class TemplateVersion extends Model
 
     public function template()
     {
-        return $this->belongsTo(Template::class, 'template_id');
+        return $this->belongsTo(config('whatsapp.models.template'), 'template_id');
     }
 }

--- a/src/Models/Website.php
+++ b/src/Models/Website.php
@@ -26,6 +26,6 @@ class Website extends Model
 
     public function businessProfile()
     {
-        return $this->belongsTo(WhatsappBusinessProfile::class, 'whatsapp_business_profile_id');
+        return $this->belongsTo(config('whatsapp.models.business_profile'), 'whatsapp_business_profile_id');
     }
 }

--- a/src/Models/WhatsappBusinessAccount.php
+++ b/src/Models/WhatsappBusinessAccount.php
@@ -38,11 +38,11 @@ class WhatsappBusinessAccount extends Model
 
     public function phoneNumbers()
     {
-        return $this->hasMany(WhatsappPhoneNumber::class, 'whatsapp_business_account_id', 'whatsapp_business_id');
+        return $this->hasMany(config('whatsapp.models.phone_number'), 'whatsapp_business_account_id', 'whatsapp_business_id');
     }
 
     public function templates()
     {
-        return $this->hasMany(Template::class, 'whatsapp_business_id');
+        return $this->hasMany(config('whatsapp.models.template'), 'whatsapp_business_id');
     }
 }

--- a/src/Models/WhatsappBusinessProfile.php
+++ b/src/Models/WhatsappBusinessProfile.php
@@ -31,13 +31,13 @@ class WhatsappBusinessProfile extends Model
 
     public function websites()
     {
-        return $this->hasMany(Website::class, 'whatsapp_business_profile_id');
+        return $this->hasMany(config('whatsapp.models.website'), 'whatsapp_business_profile_id');
     }
 
     public function phoneNumber()
     {
         return $this->hasOne(
-            WhatsappPhoneNumber::class,
+            config('whatsapp.models.phone_number'),
             'whatsapp_business_profile_id', // Clave foránea en phone_numbers
             'whatsapp_business_profile_id'  // Clave primaria en este modelo
         );

--- a/src/Models/WhatsappFlow.php
+++ b/src/Models/WhatsappFlow.php
@@ -51,13 +51,13 @@ class WhatsappFlow extends Model
 
     public function screens()
     {
-        return $this->hasMany(WhatsappFlowScreen::class, 'flow_id', 'flow_id');
+        return $this->hasMany(config('whatsapp.models.flow_screen'), 'flow_id', 'flow_id');
     }
 
     public function templates()
     {
         return $this->belongsToMany(
-            Template::class,
+            config('whatsapp.models.template'),
             'whatsapp_template_flows',
             'flow_id',
             'template_id'
@@ -66,13 +66,13 @@ class WhatsappFlow extends Model
 
     public function sessions()
     {
-        return $this->hasMany(WhatsappFlowSession::class, 'flow_id', 'flow_id');
+        return $this->hasMany(config('whatsapp.models.flow_session'), 'flow_id', 'flow_id');
     }
 
     public function whatsappBusinessAccount()
     {
         return $this->belongsTo(
-            WhatsappBusinessAccount::class,
+            config('whatsapp.models.business_account'),
             'whatsapp_business_account_id',
             'whatsapp_business_id'
         );

--- a/src/Models/WhatsappFlowEvent.php
+++ b/src/Models/WhatsappFlowEvent.php
@@ -33,6 +33,6 @@ class WhatsappFlowEvent extends Model
 
     public function session()
     {
-        return $this->belongsTo(WhatsappFlowSession::class, 'session_id', 'flow_session_id');
+        return $this->belongsTo(config('whatsapp.models.flow_session'), 'session_id', 'flow_session_id');
     }
 }

--- a/src/Models/WhatsappFlowResponse.php
+++ b/src/Models/WhatsappFlowResponse.php
@@ -30,11 +30,11 @@ class WhatsappFlowResponse extends Model
 
     public function session()
     {
-        return $this->belongsTo(WhatsappFlowSession::class, 'session_id', 'flow_session_id');
+        return $this->belongsTo(config('whatsapp.models.flow_session'), 'session_id', 'flow_session_id');
     }
 
     public function screen()
     {
-        return $this->belongsTo(WhatsappFlowScreen::class, 'screen_id', 'screen_id');
+        return $this->belongsTo(config('whatsapp.models.flow_screen'), 'screen_id', 'screen_id');
     }
 }

--- a/src/Models/WhatsappFlowScreen.php
+++ b/src/Models/WhatsappFlowScreen.php
@@ -38,11 +38,11 @@ class WhatsappFlowScreen extends Model
 
     public function flow()
     {
-        return $this->belongsTo(WhatsappFlow::class, 'flow_id', 'flow_id');
+        return $this->belongsTo(config('whatsapp.models.flow'), 'flow_id', 'flow_id');
     }
 
     public function elements()
     {
-        return $this->hasMany(WhatsappScreenElement::class, 'screen_id', 'screen_id');
+        return $this->hasMany(config('whatsapp.models.screen_element'), 'screen_id', 'screen_id');
     }
 }

--- a/src/Models/WhatsappFlowSession.php
+++ b/src/Models/WhatsappFlowSession.php
@@ -35,16 +35,16 @@ class WhatsappFlowSession extends Model
 
     public function flow()
     {
-        return $this->belongsTo(WhatsappFlow::class, 'flow_id', 'flow_id');
+        return $this->belongsTo(config('whatsapp.models.flow'), 'flow_id', 'flow_id');
     }
 
     public function responses()
     {
-        return $this->hasMany(WhatsappFlowResponse::class, 'session_id', 'flow_session_id');
+        return $this->hasMany(config('whatsapp.models.flow_response'), 'session_id', 'flow_session_id');
     }
 
     public function events()
     {
-        return $this->hasMany(WhatsappFlowEvent::class, 'session_id', 'flow_session_id');
+        return $this->hasMany(config('whatsapp.models.flow_event'), 'session_id', 'flow_session_id');
     }
 }

--- a/src/Models/WhatsappPhoneNumber.php
+++ b/src/Models/WhatsappPhoneNumber.php
@@ -43,18 +43,18 @@ class WhatsappPhoneNumber extends Model
 
     public function messages()
     {
-        return $this->hasMany(Message::class, 'whatsapp_phone_id');
+        return $this->hasMany(config('whatsapp.models.message'), 'whatsapp_phone_id');
     }
 
     public function businessAccount()
     {
-        return $this->belongsTo(WhatsappBusinessAccount::class, 'whatsapp_business_account_id');
+        return $this->belongsTo(config('whatsapp.models.business_account'), 'whatsapp_business_account_id');
     }
 
     public function businessProfile()
     {
         return $this->belongsTo(
-            WhatsappBusinessProfile::class,
+            config('whatsapp.models.business_profile'),
             'whatsapp_business_profile_id',
             'whatsapp_business_profile_id'
         );
@@ -62,7 +62,7 @@ class WhatsappPhoneNumber extends Model
 
     public function contacts()
     {
-        return $this->hasMany(Contact::class)
+        return $this->hasMany(config('whatsapp.models.contact'))
                     ->whereHas('whatsapp_messages', function ($query) {
                         $query->where('whatsapp_phone_id', $this->phone_number_id);
                     })
@@ -71,6 +71,6 @@ class WhatsappPhoneNumber extends Model
 
     public function blockedUsers()
     {
-        return $this->hasMany(BlockedUser::class, 'phone_number_id');
+        return $this->hasMany(config('whatsapp.models.blocked_user'), 'phone_number_id');
     }
 }

--- a/src/Models/WhatsappScreenElement.php
+++ b/src/Models/WhatsappScreenElement.php
@@ -40,6 +40,6 @@ class WhatsappScreenElement extends Model
 
     public function screen()
     {
-        return $this->belongsTo(WhatsappFlowScreen::class, 'screen_id', 'screen_id');
+        return $this->belongsTo(config('whatsapp.models.flow_screen'), 'screen_id', 'screen_id');
     }
 }

--- a/src/Models/WhatsappTemplateFlow.php
+++ b/src/Models/WhatsappTemplateFlow.php
@@ -31,11 +31,11 @@ class WhatsappTemplateFlow extends Model
 
     public function template()
     {
-        return $this->belongsTo(Template::class, 'template_id', 'template_id');
+        return $this->belongsTo(config('whatsapp.models.template'), 'template_id', 'template_id');
     }
 
     public function flow()
     {
-        return $this->belongsTo(WhatsappFlow::class, 'flow_id', 'flow_id');
+        return $this->belongsTo(config('whatsapp.models.flow'), 'flow_id', 'flow_id');
     }
 }

--- a/src/Services/TemplateBuilder.php
+++ b/src/Services/TemplateBuilder.php
@@ -292,13 +292,13 @@ class TemplateBuilder
             // Estructura diferente para parámetros NAMED vs POSITIONAL
             if ($this->parameterFormat === 'NAMED') {
                 $namedParams = [];
-                foreach ($placeholders as $paramName) {
-                    if (!isset($example[$paramName])) {
+                foreach ($placeholders as $key => $paramName) {
+                    if (!isset($example[$key])) {
                         throw new InvalidArgumentException("Falta valor para parámetro: $paramName");
                     }
                     $namedParams[] = [
                         'param_name' => $paramName,
-                        'example' => $example[$paramName],
+                        'example' => $example[$key],
                     ];
                 }
                 $formattedExample = ['body_text_named_params' => $namedParams];
@@ -615,7 +615,7 @@ class TemplateBuilder
     protected function validateNamedParameters(array $placeholders, ?array $example, string $type): void
     {
         foreach ($placeholders as $placeholder) {
-            if (!preg_match('/^[a-zA-Z_\$][a-zA-Z0-9_\$]*$/', $placeholder)) {
+            if (!preg_match('/^[a-z_][a-z0-9_]*$/', $placeholder)) {
                 throw new InvalidArgumentException(
                     "Nombre de parámetro inválido: '$placeholder'. Solo caracteres alfanuméricos y guiones bajos"
                 );
@@ -624,7 +624,8 @@ class TemplateBuilder
 
         if ($example) {
             $exampleKeys = array_keys($example);
-            $missingParams = array_diff($placeholders, $exampleKeys);
+            $placeholderKeys = array_keys($placeholders);
+            $missingParams = array_diff($placeholderKeys, $exampleKeys);
 
             if (!empty($missingParams)) {
                 throw new InvalidArgumentException(


### PR DESCRIPTION
Ahora el webhook actualiza el campo "is_active", además, re corrigieron unos problemas al crear plantillas con parámetros NAMED; ya lo hace correctamente, SIN EMBARGO, por mas que intenté, el enviar las plantillas con campos NAMED no está funcionando por lo que considero problemas directamente con las apis de whatsapp business meta, no por la programación de este paquete, ya que intenté llamar la plantilla directamente con POSTMAN y no lo hace correctamente, por lo que considero prudente que mejor no se use el modo de variables "NAMED"