### PR TITLE
Corrección al guardar el json del template

### DIFF
--- a/src/Http/Controllers/WhatsappWebhookController.php
+++ b/src/Http/Controllers/WhatsappWebhookController.php
@@ -997,7 +997,7 @@ class WhatsappWebhookController extends Controller
         $reason = $templateData['reason'] ?? null;
 
         // Calcular hash del contenido
-        $contentHash = sha1(json_encode($components));
+        $contentHash = md5(json_encode($components));
 
         // Verificar si ya existe una versión con este hash
         $existingVersion = $template->versions()

--- a/src/Services/TemplateBuilder.php
+++ b/src/Services/TemplateBuilder.php
@@ -764,9 +764,6 @@ class TemplateBuilder
                 'json' => json_encode($this->templateData, JSON_UNESCAPED_UNICODE),
             ]);
 
-            // Crear versión inicial
-            $this->createInitialVersion($template, $response);
-
             try {
                 $endpoint = Endpoints::build(Endpoints::GET_TEMPLATE, [
                     'template_id' => $response['id'],
@@ -785,18 +782,21 @@ class TemplateBuilder
                     $headers
                 );
 
-                // Actualizar el registro con los datos completos que incluyen URLs
+                // Crear el registro de la plantilla en la base de datos
                 $template->update([
-                    'json' => json_encode($fullTemplateResponse, JSON_UNESCAPED_UNICODE)
+                    'status' => $fullTemplateResponse['status'] ?? 'PENDING',
+                    'json' => json_encode($fullTemplateResponse, JSON_UNESCAPED_UNICODE),
                 ]);
-                
+
+                // Crear versión inicial
+                $this->createInitialVersion($template, $fullTemplateResponse);
+
             } catch (\Exception $e) {
                 Log::channel('whatsapp')->error('Error al obtener detalles completos de la plantilla', [
                     'template_id' => $response['id'] ?? 'unknown',
                     'error' => $e->getMessage()
                 ]);
             }
-
 
 
             // Reiniciar el estado del builder
@@ -838,8 +838,8 @@ class TemplateBuilder
     {
         return WhatsappModelResolver::template_version()->create([
             'template_id' => $template->template_id,
-            'version_hash' => md5(json_encode($this->templateData['components'])),
-            'template_structure' => $this->templateData['components'],
+            'version_hash' => md5(json_encode($apiResponse['components'])),
+            'template_structure' => $apiResponse['components'],
             'status' => $apiResponse['status'] ?? 'PENDING',
             'is_active' => ($apiResponse['status'] === 'APPROVED'),
         ]);

--- a/src/Services/TemplateBuilder.php
+++ b/src/Services/TemplateBuilder.php
@@ -782,7 +782,7 @@ class TemplateBuilder
                     $headers
                 );
 
-                // Crear el registro de la plantilla en la base de datos
+                // Actualizar el registro con los datos completos que incluyen URLs
                 $template->update([
                     'status' => $fullTemplateResponse['status'] ?? 'PENDING',
                     'json' => json_encode($fullTemplateResponse, JSON_UNESCAPED_UNICODE),


### PR DESCRIPTION
Se corrige como se guarda el json del template, además en el controlador del webhook hay se usaba el método sha1 para el campo version_hash cuando debería ser md5