### PR TITLE
Fix migración 2024_12_17_195818_create_websites_table

### DIFF
--- a/src/Database/Migrations/2024_12_17_195818_create_websites_table.php
+++ b/src/Database/Migrations/2024_12_17_195818_create_websites_table.php
@@ -13,13 +13,13 @@ return new class extends Migration
     {
         Schema::create('whatsapp_websites', function (Blueprint $table) {
             $table->ulid('website_id')->primary();
-            $table->foreignUuid('whatsapp_business_profile_id')
+            $table->foreignUlid('whatsapp_business_profile_id')
                 ->constrained(
-                    table: 'whatsapp_business_profiles', 
-                    column: 'whatsapp_business_profile_id'
+                    'whatsapp_business_profiles',
+                    'whatsapp_business_profile_id'
                 )
                 ->onDelete('cascade')
-                ->index(); 
+                ->index();
             $table->string('website', 512);
             $table->timestamps();
             $table->softDeletes();


### PR DESCRIPTION
En la migración 2024_12_17_195818_create_websites_table se intenta crear una llave foránea así:

$table->foreignUuid('whatsapp_business_profile_id')

Sin embargo, el tipo de dato en la tabla whatsapp_business_profiles del campo whatsapp_business_profile_id es de tipo ULID, no UUID, lo que provocará un error que no permitirá ejecutar las demás migraciones, se corrige cambiando por:

foreignUlid