### PR TITLE
Corrección en migración

### DIFF
--- a/src/Database/Migrations/2026_05_05_000002_add_meta_business_id_to_whatsapp_business_accounts.php
+++ b/src/Database/Migrations/2026_05_05_000002_add_meta_business_id_to_whatsapp_business_accounts.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::table('whatsapp_business_accounts', function (Blueprint $table) {
             if (!Schema::hasColumn('whatsapp_business_accounts', 'meta_business_id')) {
-                $table->string('meta_business_id')->nullable()->after('company_id');
+                $table->string('meta_business_id')->nullable()->after('whatsapp_business_id');
                 $table->index('meta_business_id');
             }
         });


### PR DESCRIPTION
Corrección en migración, el campo company_id no existe en este contexto del paquete, se cambia por un after('whatsapp_business_id')