### PR TITLE
Fix change stats

### DIFF
--- a/src/Database/Migrations/2026_05_07_000001_add_status_date_indexes_to_whatsapp_messages_table.php
+++ b/src/Database/Migrations/2026_05_07_000001_add_status_date_indexes_to_whatsapp_messages_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('whatsapp_messages', function (Blueprint $table) {
+            // delivered_at ya está indexado en la migración base create_messages_table.
+            $table->index('read_at', 'idx_whatsapp_messages_read_at');
+            $table->index('failed_at', 'idx_whatsapp_messages_failed_at');
+            $table->index('edited_at', 'idx_whatsapp_messages_edited_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('whatsapp_messages', function (Blueprint $table) {
+            $table->dropIndex('idx_whatsapp_messages_read_at');
+            $table->dropIndex('idx_whatsapp_messages_failed_at');
+            $table->dropIndex('idx_whatsapp_messages_edited_at');
+        });
+    }
+};

--- a/src/Services/WebhookProcessors/BaseWebhookProcessor.php
+++ b/src/Services/WebhookProcessors/BaseWebhookProcessor.php
@@ -1430,14 +1430,16 @@ class BaseWebhookProcessor implements WebhookProcessorInterface
         $timestamp   = $status['timestamp'] ?? null;
         $errorCode   = null;
 
-        if( !empty($message->delivered_at) ){
-            $statusValue = 'delivered';
-        }
-        if( !empty($message->read_at) ){
-            $statusValue = 'read';
-        }
-        if( !empty($message->failed_at) ){
-            $statusValue = 'failed';
+        if( empty($statusValue) ){
+            if( !empty($message->delivered_at) ){
+                $statusValue = 'delivered';
+            }
+            if( !empty($message->read_at) ){
+                $statusValue = 'read';
+            }
+            if( !empty($message->failed_at) ){
+                $statusValue = 'failed';
+            }
         }
 
         $updateData  = ['status' => $statusValue];
@@ -1490,6 +1492,16 @@ class BaseWebhookProcessor implements WebhookProcessorInterface
                 }
             }
         }
+
+        Log::channel('whatsapp')->info('Data to update message status.', [
+            'message_id' => $message->message_id,
+            'wa_id' => $message->wa_id,
+            'current_status' => $message->status,
+            'new_status' => $statusValue,
+            'timestamp' => $timestamp,
+            'status_payload' => $status,
+            'update_data' => $updateData,
+        ]);
 
         $message->update($updateData);
         return $message;

--- a/src/Services/WebhookProcessors/BaseWebhookProcessor.php
+++ b/src/Services/WebhookProcessors/BaseWebhookProcessor.php
@@ -1427,22 +1427,48 @@ class BaseWebhookProcessor implements WebhookProcessorInterface
     protected function updateMessageStatus(Model $message, array $status): Model
     {
         $statusValue = $status['status'] ?? null;
-        $timestamp   = $status['timestamp'] ?? null;
+        $timestamp   = $status['timestamp'] ?? now()->timestamp;
         $errorCode   = null;
+        $updateData  = [];
 
-        if( empty($statusValue) ){
-            if( !empty($message->delivered_at) ){
-                $statusValue = 'delivered';
-            }
-            if( !empty($message->read_at) ){
-                $statusValue = 'read';
-            }
-            if( !empty($message->failed_at) ){
-                $statusValue = 'failed';
-            }
+        if ($timestamp) {
+            $date = \Carbon\Carbon::createFromTimestamp($timestamp);
+
+            // Solo guardar el timestamp si el campo aún no tiene valor en la DB.
+            // Los webhooks pueden llegar duplicados o desordenados; el primer registro
+            // cronológico de cada evento es el canónico y no debe sobreescribirse.
+            match ($statusValue) {
+                'delivered' => empty($message->delivered_at) ? $updateData['delivered_at'] = $date : null,
+                'read'      => empty($message->read_at)      ? $updateData['read_at']      = $date : null,
+                'failed'    => empty($message->failed_at)    ? $updateData['failed_at']    = $date : null,
+                default     => null,
+            };
         }
 
-        $updateData  = ['status' => $statusValue];
+        // Prioridad de estados: failed(4) > read(3) > delivered(2) > sent(1)
+        // Los webhooks pueden llegar desordenados; nunca debemos degradar a un estado
+        // de menor prioridad que el ya almacenado en la base de datos.
+        $statusPriority = [
+            'failed'    => 4,
+            'read'      => 3,
+            'delivered' => 2,
+            'sent'      => 1,
+        ];
+
+        $effectiveDbStatus = null;
+        if (!empty($message->failed_at))       $effectiveDbStatus = 'failed';
+        elseif (!empty($message->read_at))     $effectiveDbStatus = 'read';
+        elseif (!empty($message->delivered_at)) $effectiveDbStatus = 'delivered';
+
+        $incomingPriority = $statusPriority[$statusValue] ?? 0;
+        $dbPriority       = $statusPriority[$effectiveDbStatus] ?? 0;
+
+        // Solo reemplazamos el status si el que llega tiene igual o mayor prioridad
+        if ($dbPriority > $incomingPriority) {
+            $statusValue = $effectiveDbStatus;
+        }
+
+        $updateData['status']  = $statusValue;
 
         // Guardar BSUID del destinatario si llega en el status (presente en delivered/read cuando se envió por BSUID)
         if (!empty($status['recipient_user_id'])) {
@@ -1450,17 +1476,6 @@ class BaseWebhookProcessor implements WebhookProcessorInterface
         }
         if (!empty($status['parent_recipient_user_id'])) {
             $updateData['parent_recipient_bsuid'] = $status['parent_recipient_user_id'];
-        }
-
-        if ($timestamp) {
-            $date = \Carbon\Carbon::createFromTimestamp($timestamp);
-
-            match ($statusValue) {
-                'delivered' => $updateData['delivered_at'] = $date,
-                'read' => $updateData['read_at'] = $date,
-                'failed' => $updateData['failed_at'] = $date,
-                default => null
-            };
         }
 
         // Procesar errores de forma robusta
@@ -1500,7 +1515,7 @@ class BaseWebhookProcessor implements WebhookProcessorInterface
             'new_status' => $statusValue,
             'timestamp' => $timestamp,
             'status_payload' => $status,
-            'update_data' => $updateData,
+            'updateData' => $updateData,
         ]);
 
         $message->update($updateData);


### PR DESCRIPTION
Este fix corrige el problema de que los webhook pueden dispararse en desorden, es decir, dispararse un webhook con status sent, luego otro con status read y al final otro con status delivered, incluso peude repetir estos webhook y disparar al final 2 veces el webhook delivered, esto afectaba porque podía haberse marcado con status "read" pero el último mensaje marcarlo con status "delivered" lo que es un problema porque en realidad ese mensaje ya está leído, esto lo corrige y además creo una migración para crear unos índices alos campos failed_at, read_at y edited_at